### PR TITLE
declare which files are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "files": [
+    "dist/src/*",
+    "!dist/src/*.test.*"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "jest --verbose",


### PR DESCRIPTION
Relying on an allowed list of files is more robust as miscellaneous things like `docker-compose.yml` or `libmalan-0.0.11.tgz` show up. Note that npm will take care to always include special files, so they are omitted in this list.

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files

```
$ npm pack
npm notice 
npm notice 📦  libmalan@0.0.11
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE               
npm notice 2.6kB README.md             
npm notice 95B   dist/src/config.d.ts  
npm notice 77B   dist/src/config.js    
npm notice 135B  dist/src/index.d.ts   
npm notice 718B  dist/src/index.js     
npm notice 1.2kB dist/src/sessions.d.ts
npm notice 2.0kB dist/src/sessions.js  
npm notice 2.4kB dist/src/users.d.ts   
npm notice 3.8kB dist/src/users.js     
npm notice 356B  dist/src/utils.d.ts   
npm notice 300B  dist/src/utils.js     
npm notice 921B  package.json          
npm notice === Tarball Details === 
npm notice name:          libmalan                                
npm notice version:       0.0.11                                  
npm notice filename:      libmalan-0.0.11.tgz                     
npm notice package size:  4.5 kB                                  
npm notice unpacked size: 15.7 kB                                 
npm notice shasum:        3174703a9f702a9149ee4cafdde589dae0e02cb4
npm notice integrity:     sha512-2GgDkft6MFjnh[...]ukOiK3sokn2UQ==
npm notice total files:   13
```

closes #11