### PR TITLE
parse errors on all users and sessions endpoints

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,30 @@
+export class MalanError extends Error {
+  detail: string;
+
+  constructor(data: { detail: string; message: string }) {
+    super(data.message);
+    this.detail = data.detail;
+  }
+}
+
+type Response = {
+  response: {
+    body: {
+      errors?: {
+        detail: string;
+        message: string;
+      };
+    };
+  };
+};
+
+function isResponse(e: unknown): e is Response {
+  return typeof e === "object" && !!e["response"];
+}
+
+export function handleResponseError(e: unknown): void {
+  if (isResponse(e) && e.response.body.errors) {
+    throw new MalanError(e.response.body.errors);
+  }
+  throw e;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,7 @@ export{
   createUser,
   updateUser
 } from './users'
+
+export {
+  MalanError
+} from './errors'

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -3,6 +3,7 @@ const superagent = require('superagent');
 import { fullUrl, BaseResp } from './utils';
 
 import MalanConfig from './config';
+import { handleResponseError } from './errors';
 
 type BaseSessionResponse = {
   api_token: string,
@@ -27,6 +28,7 @@ function login(c: MalanConfig, username: string, password: string, expirationSec
     .post(fullUrl(c, "/api/sessions"))
     .send({session: {username, password, never_expires: expirationSeconds === 0, expires_in_seconds: expirationSeconds === 0 ? undefined : expirationSeconds, }})
     .then(resp => ({ ...resp, data: resp.body.data, ...resp.body.data }))
+    .catch(handleResponseError)
 }
 
 function logout(c: MalanConfig, user_id: string, session_id: string) {
@@ -34,6 +36,7 @@ function logout(c: MalanConfig, user_id: string, session_id: string) {
     .del(fullUrl(c, `/api/users/${user_id}/sessions/${session_id}`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: resp.body.data, ...resp.body.data }))
+    .catch(handleResponseError)
 }
 
 function getSession(c: MalanConfig, user_id: string, session_id: string) {
@@ -41,6 +44,7 @@ function getSession(c: MalanConfig, user_id: string, session_id: string) {
     .get(fullUrl(c, `/api/users/${user_id}/sessions/${session_id}`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: resp.body.data, ...resp.body.data }))
+    .catch(handleResponseError)
 }
 
 function isValid(c: MalanConfig, user_id: string, session_id: string) {
@@ -54,6 +58,7 @@ function isValidWithRole(c: MalanConfig, user_id: string, session_id: string, ro
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: resp.body.data, ...resp.body.data }))
     .then(resp => resp.data.is_valid)
+    .catch(handleResponseError)
 }
 
 export {

--- a/src/users.ts
+++ b/src/users.ts
@@ -3,6 +3,7 @@ const superagent = require('superagent');
 import { fullUrl, BaseResp } from './utils';
 
 import MalanConfig from './config';
+import { handleResponseError } from './errors';
 
 type BaseUserResp = {
   id:  string,
@@ -72,7 +73,7 @@ function createUser(c: MalanConfig, params: CreateUserParams): Promise<UserRespo
     .post(fullUrl(c, "/api/users"))
     .send({user: params})
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function getUserByUsername(c: MalanConfig, username: string): Promise<UserResponse> {
@@ -80,7 +81,7 @@ function getUserByUsername(c: MalanConfig, username: string): Promise<UserRespon
     .get(fullUrl(c, `/api/users/${username}`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function getUser(c: MalanConfig, id: string): Promise<UserResponse> {
@@ -88,7 +89,7 @@ function getUser(c: MalanConfig, id: string): Promise<UserResponse> {
     .get(fullUrl(c, `/api/users/${id}`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function whoamiFull(c: MalanConfig): Promise<UserResponse> {
@@ -96,7 +97,7 @@ function whoamiFull(c: MalanConfig): Promise<UserResponse> {
     .get(fullUrl(c, `/api/users/me`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function whoami(c: MalanConfig): Promise<WhoamiResponse> {
@@ -104,7 +105,7 @@ function whoami(c: MalanConfig): Promise<WhoamiResponse> {
     .get(fullUrl(c, `/api/users/whoami`))
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function updateUser(c: MalanConfig, id: string, params: UpdateUserParams): Promise<UserResponse> {
@@ -113,7 +114,7 @@ function updateUser(c: MalanConfig, id: string, params: UpdateUserParams): Promi
     .send({user: params})
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function adminUpdateUser(c: MalanConfig, id: string, params: UpdateUserParams): Promise<UserResponse> {
@@ -122,7 +123,7 @@ function adminUpdateUser(c: MalanConfig, id: string, params: UpdateUserParams): 
     .send({user: params})
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function acceptTos(c: MalanConfig, id: string, accept: boolean): Promise<UserResponse> {
@@ -131,7 +132,7 @@ function acceptTos(c: MalanConfig, id: string, accept: boolean): Promise<UserRes
     .send({user: {accept_tos: accept}})
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 function acceptPrivacyPolicy(c: MalanConfig, id: string, accept: boolean): Promise<UserResponse> {
@@ -140,7 +141,7 @@ function acceptPrivacyPolicy(c: MalanConfig, id: string, accept: boolean): Promi
     .send({user: {accept_privacy_policy: accept}})
     .set('Authorization', `Bearer ${c.api_token}`)
     .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
-    //.catch(err => ({ ...err, ok: false }))
+    .catch(handleResponseError)
 }
 
 export {


### PR DESCRIPTION
The `handleResponseError` function looks for Malan responses with a certain shape and throws `MalanError`. Any other unknown error, like a networking issue, is re-thrown without modification.

closes #17 