### PR TITLE
Add ErrorResponse type for convenience

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,6 +1,6 @@
 const superagent = require('superagent');
 
-import { fullUrl, BaseResp } from './utils';
+import { fullUrl, BaseResp, ErrorResponse } from './utils';
 
 import MalanConfig from './config';
 import { handleResponseError } from './errors';
@@ -72,4 +72,5 @@ export {
   IsValidWithRoleResponse,
   getSession,
   SessionResponse,
+  ErrorResponse,
 }

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,6 +1,6 @@
 const superagent = require('superagent');
 
-import { fullUrl, BaseResp } from './utils';
+import { fullUrl, BaseResp, ErrorResponse } from './utils';
 
 import MalanConfig from './config';
 import { handleResponseError } from './errors';
@@ -160,4 +160,5 @@ export {
   updateUser,
   acceptTos,
   acceptPrivacyPolicy,
+  ErrorResponse,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,25 +1,45 @@
-import MalanConfig from './config';
+import MalanConfig from "./config";
 
 interface BaseResp {
-  data: any
-  body: any,
-  header: any,
-  headers: any,
-  status: number,
-  statusCode: number,
-  ok: boolean,
-  error: boolean,
-  forbidden: boolean,
-  unauthorized: boolean,
+  data: any;
+  body: any;
+  header: any;
+  headers: any;
+  status: number;
+  statusCode: number;
+  ok: boolean;
+  error: boolean;
+  forbidden: boolean;
+  unauthorized: boolean;
+}
+
+interface ErrorResponse {
+  error: {
+    ok: boolean;
+    code: 400 | 401 | 403 | 404 | 422 | 423 | 429 | 461 | 462 | 500;
+    message?: string;
+    detail:
+      | "Bad Request"
+      | "Unauthorized"
+      | "Forbidden"
+      | "Not Found"
+      | "Unprocessable Entity"
+      | "Locked"
+      | "Too Many Requests"
+      | "Terms of Service Required"
+      | "Privacy Policy Required"
+      | "Internal Server Error";
+  };
 }
 
 function fullUrl(config: MalanConfig, path: string): string {
   return config.host.toLowerCase().match(/^https?:\/\//)
     ? `${config.host}${path}`
-    : `http://${config.host}${path}`
+    : `http://${config.host}${path}`;
 }
 
 export {
   BaseResp,
+  ErrorResponse,
   fullUrl,
 }


### PR DESCRIPTION
If an API endpoint returns an error, this ErrorResponse describes what
it will look like