### PR TITLE
Export * to avoid having to enumerate all functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,3 @@
-export {
-  login,
-  LoginResponse,
-  logout,
-  LogoutResponse,
-} from './sessions'
-
-export{
-  getUser,
-  createUser,
-  updateUser,
-  getUserByUsername,
-} from './users'
-
-export {
-  MalanError
-} from './errors'
+export * from './sessions'
+export * from './users'
+export * from './errors'


### PR DESCRIPTION
    Also helps so we don't forget to export functions as we add them.  We're
    already exporting them from the defined module so this is a second
    explicit export