### PR TITLE
include validation errors in MalanError

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,31 +1,44 @@
 export class MalanError extends Error {
-  detail: string;
+  code: ErrorBody["code"];
+  detail: ErrorBody["detail"];
+  token_expired?: ErrorBody["token_expired"];
+  errors?: ErrorBody["errors"];
 
-  constructor(data: { detail: string; message: string }) {
+  constructor(data: ErrorBody) {
     super(data.message);
+    this.code = data.code;
     this.detail = data.detail;
+    this.token_expired = data.token_expired;
+    this.errors = data.errors;
   }
 }
 
+type DataBody<T = unknown> = {
+  data: T;
+};
+
+type ErrorBody = {
+  ok: false;
+  code: 400 | 401 | 403 | 404 | 422 | 423 | 429 | 461 | 462 | 500;
+  detail:
+    | "Bad Request"
+    | "Unauthorized"
+    | "Forbidden"
+    | "Not Found"
+    | "Unprocessable Entity"
+    | "Locked"
+    | "Too Many Requests"
+    | "Terms of Service Required"
+    | "Privacy Policy Required"
+    | "Internal Server Error";
+  message: string;
+  token_expired?: true;
+  errors?: Record<string, string[]>;
+};
+
 type Response = {
   response: {
-    body: {
-      ok: boolean;
-      code: 400 | 401 | 403 | 404 | 422 | 423 | 429 | 461 | 462 | 500;
-      message: string;
-      errors?: Record<string, string[]>;
-      detail:
-        | "Bad Request"
-        | "Unauthorized"
-        | "Forbidden"
-        | "Not Found"
-        | "Unprocessable Entity"
-        | "Locked"
-        | "Too Many Requests"
-        | "Terms of Service Required"
-        | "Privacy Policy Required"
-        | "Internal Server Error";
-    };
+    body: DataBody | ErrorBody;
   };
 };
 
@@ -33,8 +46,12 @@ function isResponse(e: unknown): e is Response {
   return typeof e === "object" && !!e["response"];
 }
 
+function isErrorBody(b: Response["response"]["body"]): b is ErrorBody {
+  return b["ok"] === false;
+}
+
 export function handleResponseError(e: unknown): void {
-  if (isResponse(e) && e.response.body && !e.response.body.ok) {
+  if (isResponse(e) && isErrorBody(e.response.body)) {
     throw new MalanError(e.response.body);
   }
   throw e;


### PR DESCRIPTION
Fixes `MalanError` to include the errors key mentioned in the 422 message:

> The request was syntactically correct, but some or all of the parameters failed validation.  See errors key for details

Copying an object into a class is a little annoying, but it seems worthwhile for the easy affordance of `instanceof` checks when application developers need to detect and handle specific cases such as duplicate usernames.