### PR TITLE
Fix createUser test

### DIFF
--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -65,7 +65,7 @@ describe('#createUser', () => {
     expect(newUser.data.username).toMatch(/^test/)
     expect(newUser.data.last_name).toEqual('Buddy')
     expect(newUser.data.custom_attrs).toEqual(custom_attrs)
-    expect(newUser.data.birthday).toEqual(date.toISOString().split('.')[0]+"Z")
+    expect(newUser.data.birthday).toEqual(date.toISOString().split('T')[0])
   });
 
   it("Errors with duplicate email", async () => {

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -80,7 +80,7 @@ export async function newRegularAccount(): Promise<users.BaseUserResp & { sessio
     ra['session'] = session
     return ra
   } catch(e) {
-    console.log('CAUGHT THE ERROR')
+    console.log('[newRegularAccount()]: Caught an error creating an account')
     console.dir(e)
     return e.response
   }


### PR DESCRIPTION
This got missed when we changed the birthdate in malan to be a day
instead of a timestamp.  Lesson learned:  always `dc pull` before
running tests to make sure you're testing against the latest version of
Malan!