### PR TITLE
Add admin password reset and fix tests

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,8 @@ export class MalanError extends Error {
   detail: ErrorBody["detail"];
   token_expired?: ErrorBody["token_expired"];
   errors?: ErrorBody["errors"];
+  // Error has a message property so this needs a different name to avoid collision
+  messageStr?: ErrorBody["message"];
 
   constructor(data: ErrorBody) {
     super(data.message);
@@ -10,6 +12,7 @@ export class MalanError extends Error {
     this.detail = data.detail;
     this.token_expired = data.token_expired;
     this.errors = data.errors;
+    this.messageStr = data.message;
   }
 }
 

--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -1,4 +1,5 @@
 import * as users from './users';
+import * as sessions from './sessions';
 import MalanConfig from './config';
 import { base, forSession } from '../test/test_config';
 
@@ -120,6 +121,36 @@ describe('#acceptPrivacyPolicy', () => {
 
     const acceptedUser = await users.acceptPrivacyPolicy(forSession(ra.session), ra.id, true)
     expect(acceptedUser.data.privacy_policy_accepted).toEqual(true)
+  });
+})
+
+describe('adminResetPasswordRequest', () => {
+  it('Requests a password reset token', async () => {
+    const ra = await regularAccount()
+    const root = await rootAccount()
+
+    const origUser = await users.getUser(forSession(ra.session), ra.id)
+    const resetRequest = await users.adminResetPasswordRequest(forSession(root.session), ra.id)
+    expect(resetRequest.data.password_reset_token).toMatch(/[a-zA-Z0-9]{60}/)
+  });
+})
+
+describe('adminResetPassword', () => {
+  it('Requests a password reset token', async () => {
+    const newPassword = "rabdinbewoasswird"
+    const ra = await newRegularAccount()
+    const root = await rootAccount()
+
+    const origUser = await users.getUser(forSession(ra.session), ra.id)
+    const resetRequest = await users.adminResetPasswordRequest(forSession(root.session), ra.id)
+    expect(resetRequest.data.password_reset_token).toMatch(/[a-zA-Z0-9]{60}/)
+
+    const resetResponse = await users.adminResetPassword(forSession(root.session), resetRequest.data.password_reset_token, newPassword)
+    expect(resetResponse.ok).toEqual(true)
+
+    // Login to verify new password
+    const newSession = await sessions.login(base, ra.username, newPassword)
+    expect(newSession.api_token).toMatch(/[a-zA-Z0-9]{60}/)
   });
 })
 

--- a/src/users.ts
+++ b/src/users.ts
@@ -42,6 +42,17 @@ type WhoamiResponse = BaseResp & {
   privacy_policy: string,
 }
 
+type ResetPasswordRequestResponse = BaseResp & {
+  password_reset_token: string,
+  password_reset_token_expires_at: string,
+}
+
+type ResetPasswordResponse = BaseResp & {
+  ok: boolean,
+  err?: string,
+  msg?: string,
+}
+
 interface CreateUserParams {
   email: string,
   username: string,
@@ -155,6 +166,23 @@ function deleteUser(c: MalanConfig, id: string): Promise<BaseResp> {
     .catch(handleResponseError)
 }
 
+function adminResetPasswordRequest(c: MalanConfig, id: string): Promise<ResetPasswordRequestResponse> {
+  return superagent
+    .post(fullUrl(c, `/api/admin/users/${id}/reset_password`))
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+function adminResetPassword(c: MalanConfig, token: string, newPassword: string): Promise<ResetPasswordResponse> {
+  return superagent
+    .put(fullUrl(c, `/api/admin/users/reset_password/${token}`))
+    .send({new_password: newPassword})
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
 export {
   BaseUserResp,
   UserResponse,
@@ -169,5 +197,7 @@ export {
   updateUser,
   acceptTos,
   acceptPrivacyPolicy,
-  deleteUser
+  deleteUser,
+  adminResetPasswordRequest,
+  adminResetPassword
 }

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -3,6 +3,7 @@ import * as sessions from '../src/sessions';
 
 import { base, forSession } from '../test/test_config';
 
+let root_account
 let admin_account
 let moderator_account
 let regular_account
@@ -54,11 +55,20 @@ export const randomStr = () => Math.random().toString().replace(/\./g, "")
 export const randomUsername = () => `test${randomStr()}`
 
 export async function rootAccount(): Promise<any> {
+  if (!root_account) {
+    root_account = await loginRootAccount()
+    return root_account
+  } else {
+    return root_account
+  }
+}
+
+export async function loginRootAccount(): Promise<any> {
   try {
-    let aa = rootUserParams()
-    const session = (await sessions.login(base, aa.username, aa.password)).data
-    aa['session'] = session
-    return aa
+    let root = rootUserParams()
+    const session = (await sessions.login(base, root.username, root.password)).data
+    root['session'] = session
+    return root
   } catch(e) {
     console.log('[rootAccount()]: Caught an error retrieving the root account')
     console.dir(e)

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -7,6 +7,16 @@ let admin_account
 let moderator_account
 let regular_account
 
+function rootUserParams() {
+  return {
+    email: `root@example.com`,
+    username: `root`,
+    password: `password10`,
+    first_name: `Root`,
+    last_name: 'User',
+  }
+}
+
 function adminUserParams() {
   const num = randomStr()
   return {
@@ -42,6 +52,19 @@ function regularUserParams() {
 
 export const randomStr = () => Math.random().toString().replace(/\./g, "")
 export const randomUsername = () => `test${randomStr()}`
+
+export async function rootAccount(): Promise<any> {
+  try {
+    let aa = rootUserParams()
+    const session = (await sessions.login(base, aa.username, aa.password)).data
+    aa['session'] = session
+    return aa
+  } catch(e) {
+    console.log('[rootAccount()]: Caught an error retrieving the root account')
+    console.dir(e)
+    return e.response
+  }
+}
 
 export async function adminAccount(): Promise<any> {
   if (!admin_account) {


### PR DESCRIPTION
```
commit 4a3751f99bd4e36bbeacd99b30fee85b88e2cf11 (HEAD -> add-admin-password-reset-and-fix-tests, origin/add-admin-password-reset-and-fix-tests, fix-delete-user-test)
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Wed Aug 3 18:08:22 2022 -0600

    Add implementation for reset password endpoints (admin)
    
    There are two sets of endpoints for resetting a user's password:
    
    1.  Admin API endpoints:  these allow an admin to request a password
        reset token and give it to the user somehow.  This does not result
        in malan sending any email.  It leaves validation up to the admin
    2.  Self-serve endpoints:  these allow a user to change their own
        password.  They must first request a reset.  That will trigger an
        email to be sent to them that includes a reset token.  They can then
        use that token to call the endpoint that allows setting the new
        password.
    
    This change adds support to libmalan for the **Admin** endpoints.
    
    Also adds tests for them.

commit 0a148a1dac5e4b1194697c4db5d5bb4773dbfdfa
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Wed Aug 3 18:06:58 2022 -0600

    Add message to the error object and capture from response

commit 275081f5175dea35a954dbdb23ce99ccc26f90c0
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Wed Aug 3 18:03:44 2022 -0600

    In test helper, cache root account login
    
    this way we can reuse it without the overhead of creating a new session
    every time

commit d8bb44bbb118b2f9359001bd7b1281bbf1d6f68e (origin/fix-delete-user-test)
Author: Benjamin Porter <FreedomBen@users.noreply.github.com>
Date:   Wed Aug 3 17:40:24 2022 -0600

    Fix delete user test
    
    The session token that we were using gets revoked when the user is
    deleted, so the test was failing with an unauthorized.
    
    This checks that the token is indeed revoked, and then uses the root
    account to make sure the user 404s

```