### PR TITLE
Add extension API

### DIFF
--- a/src/sessions.test.ts
+++ b/src/sessions.test.ts
@@ -47,3 +47,28 @@ describe('#isValid', () => {
     expect(await sessions.isValid(forSession(secondSession), newSession.user_id, newSession.id)).toEqual(false)
   });
 })
+
+describe('#extend', () => {
+  it('Allows extending a session', async () => {
+    // Initialize session, specifying extension parameters
+    const newSession = await sessions.login(base, "root", "password10", 60, 120, 90)
+    expect(newSession.api_token).toMatch(/[a-zA-Z0-9]{60}/)
+    expect(newSession.max_extension_secs).toEqual(120)
+    expect(timeIsClose(newSession.expires_at, 60)).toBe(true)
+    expect(timeIsClose(newSession.extendable_until, 120)).toBe(true)
+
+    // Extend session by 90 seconds
+    const extendedSession = await sessions.extend(forSession(newSession), 90)
+    expect(extendedSession.max_extension_secs).toEqual(120)
+    expect(timeIsClose(extendedSession.expires_at, 90)).toBe(true)
+    expect(timeIsClose(extendedSession.extendable_until, 120)).toBe(true)
+  });
+})
+
+function timeIsClose(date: string, seconds: number) {
+  const originalDateTime = new Date(date).getTime()
+  const desiredDateTime = (new Date().getTime()) + (seconds * 1000)
+
+  // Return true if the difference between the two times is less than 2 seconds
+  return Math.abs(originalDateTime - desiredDateTime) < seconds * 2000
+}


### PR DESCRIPTION
Session can now be extended in Malan.  This adds support for that, with two changes:

1.  Added new (optional) params to the session create (login) function. These can be used to configure what is allowed for extensions on the function.  Parameters are:

      `max_extension_secs`:  The maximum number of seconds into the future
      that sessions can be extended to at any given time.
      `extendable_until_seconds`:  The absolute latest the token will be
      valid.  No extensions can take the token life beyond this point.
      The max point is calculated at session creation time by adding
      this parameter to the current time.

2.  Added new function `session.extend(..)` that can be used to extend a token.  This takes one (optional) parameter `expireInSeconds` that includes the number of seconds into the future that the token should now be valid