### PR TITLE
add endpoint enabling admins to log out other users

### DIFF
--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -292,3 +292,42 @@ describe('#deleteUser', () => {
     expect(e2.code).toBe(404)
   });
 })
+
+describe('#adminLogoutUser', () => {
+  it('Logs out a user by invalidating their sessions', async () => {
+    const ra = await regularAccount()
+    const aa = await rootAccount()
+    
+    const userBefore = await users.whoami(forSession(ra.session))
+    expect(userBefore.data.user_id).toEqual(ra.id)
+    
+    const result = await users.adminLogoutUser(forSession(aa.session), ra.id)
+    expect(result.ok).toEqual(true)
+    
+    const error = await users.whoami(forSession(ra.session))
+      .then(
+        () => {throw new Error('should not succeed')},
+        (e) => e
+      );
+    
+    expect(error).toBeInstanceOf(MalanError)
+    expect(error.code).toBe(403)
+  });
+
+  it('Prevents non-admin users from logging out other users', async () => {
+    const ra1 = await regularAccount()
+    const ra2 = await regularAccount()
+    
+    const error = await users.adminLogoutUser(forSession(ra1.session), ra2.id)
+      .then(
+        () => {throw new Error('should not succeed')},
+        (e) => e
+      );
+    
+    expect(error).toBeInstanceOf(MalanError)
+    expect(error.code).toBe(403)
+    
+    const user = await users.whoami(forSession(ra2.session))
+    expect(user.data.user_id).toEqual(ra2.id)
+  });
+})

--- a/src/users.test.ts
+++ b/src/users.test.ts
@@ -304,7 +304,7 @@ describe('#adminLogoutUser', () => {
     const result = await users.adminLogoutUser(forSession(aa.session), ra.id)
     expect(result.ok).toEqual(true)
     
-    const error = await users.whoami(forSession(ra.session))
+    const error = await sessions.getSession(forSession(ra.session), ra.id, ra.session.id)
       .then(
         () => {throw new Error('should not succeed')},
         (e) => e
@@ -312,22 +312,5 @@ describe('#adminLogoutUser', () => {
     
     expect(error).toBeInstanceOf(MalanError)
     expect(error.code).toBe(403)
-  });
-
-  it('Prevents non-admin users from logging out other users', async () => {
-    const ra1 = await regularAccount()
-    const ra2 = await regularAccount()
-    
-    const error = await users.adminLogoutUser(forSession(ra1.session), ra2.id)
-      .then(
-        () => {throw new Error('should not succeed')},
-        (e) => e
-      );
-    
-    expect(error).toBeInstanceOf(MalanError)
-    expect(error.code).toBe(403)
-    
-    const user = await users.whoami(forSession(ra2.session))
-    expect(user.data.user_id).toEqual(ra2.id)
   });
 })

--- a/src/users.ts
+++ b/src/users.ts
@@ -53,6 +53,12 @@ type ResetPasswordResponse = BaseResp & {
   msg?: string,
 }
 
+type LogoutUserResponse = BaseResp & {
+  ok: boolean,
+  err?: string,
+  msg?: string,
+}
+
 interface CreateUserParams {
   email: string,
   username: string,
@@ -183,7 +189,7 @@ function adminResetPassword(c: MalanConfig, token: string, newPassword: string):
     .catch(handleResponseError)
 }
 
-function adminLogoutUser(c: MalanConfig, id: string): Promise<ResetPasswordResponse> {
+function adminLogoutUser(c: MalanConfig, id: string): Promise<LogoutUserResponse> {
   return superagent
     .delete(fullUrl(c, `/api/users/${id}/sessions`))
     .set('Authorization', `Bearer ${c.api_token}`)

--- a/src/users.ts
+++ b/src/users.ts
@@ -183,6 +183,14 @@ function adminResetPassword(c: MalanConfig, token: string, newPassword: string):
     .catch(handleResponseError)
 }
 
+function adminLogoutUser(c: MalanConfig, id: string): Promise<ResetPasswordResponse> {
+  return superagent
+    .delete(fullUrl(c, `/api/users/${id}/sessions`))
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
 export {
   BaseUserResp,
   UserResponse,
@@ -201,4 +209,5 @@ export {
   adminResetPasswordRequest,
   adminResetPassword,
   adminUpdateUser,
+  adminLogoutUser,
 }


### PR DESCRIPTION
required as part of [this shortcut ticket](https://app.shortcut.com/ameelio/story/10610/cdash-allow-staff-to-manage-passwords) - staff will have the option to expire existing sessions when resetting a resident's password