### PR TITLE
Add TOTP MFA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ const isAdmin = await malan.isValidWithRole(malanConfig, user.id, session_id, "a
 
 // Log the user out (this will invalidate the API token)
 session = await malan.logout(malanConfig, user.id, session_id)
+
+// --- Multi-factor authentication (TOTP) ---
+
+// Check MFA status:  "none", "pending", or "enabled"
+const status = (await malan.getTotpStatus(malanConfig, user_id)).data
+
+// Begin enrollment (requires the user's password).  Returns the secret,
+// otpauth:// URI, and a QR code SVG for the user's authenticator app.
+// These are disclosed only by this call, so display them now.
+const enrollment = (await malan.startTotpEnrollment(malanConfig, user_id, "password")).data
+
+// Confirm enrollment with a code from the authenticator app.  Returns
+// single-use backup codes (shown only once)
+const { backup_codes } = (await malan.confirmTotpEnrollment(malanConfig, user_id, "123456")).data
+
+// Once enabled, logins must also supply a TOTP or backup code
+const mfaSession = await malan.login(malanConfig, "username", "password", 0, 0, 0, "123456")
+
+// Replace the backup codes (invalidates all previous ones)
+const regenerated = (await malan.regenerateTotpBackupCodes(malanConfig, user_id, "password", "123456")).data
+
+// Turn MFA off (requires the password plus a TOTP or backup code)
+await malan.disableTotp(malanConfig, user_id, "password", "123456")
+
+// Admins can force-disable MFA for a locked-out user (no password/code;
+// revokes all of that user's sessions)
+await malan.adminDeleteTotp(adminConfig, user_id)
 ```
 
 ## Running the tests

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,9 @@ export class MalanError extends Error {
   code: ErrorBody["code"];
   detail: ErrorBody["detail"];
   token_expired?: ErrorBody["token_expired"];
+  mfa_required?: ErrorBody["mfa_required"];
+  mfa_types?: ErrorBody["mfa_types"];
+  invalid_mfa_code?: ErrorBody["invalid_mfa_code"];
   errors?: ErrorBody["errors"];
   // Error has a message property so this needs a different name to avoid collision
   messageStr?: ErrorBody["message"];
@@ -11,6 +14,9 @@ export class MalanError extends Error {
     this.code = data.code;
     this.detail = data.detail;
     this.token_expired = data.token_expired;
+    this.mfa_required = data.mfa_required;
+    this.mfa_types = data.mfa_types;
+    this.invalid_mfa_code = data.invalid_mfa_code;
     this.errors = data.errors;
     this.messageStr = data.message;
   }
@@ -22,12 +28,13 @@ type DataBody<T = unknown> = {
 
 type ErrorBody = {
   ok: false;
-  code: 400 | 401 | 403 | 404 | 422 | 423 | 429 | 461 | 462 | 500;
+  code: 400 | 401 | 403 | 404 | 409 | 422 | 423 | 429 | 461 | 462 | 500;
   detail:
     | "Bad Request"
     | "Unauthorized"
     | "Forbidden"
     | "Not Found"
+    | "Conflict"
     | "Unprocessable Entity"
     | "Locked"
     | "Too Many Requests"
@@ -36,7 +43,14 @@ type ErrorBody = {
     | "Internal Server Error";
   message: string;
   token_expired?: true;
-  errors?: Record<string, string[]>;
+  // MFA is enabled and the login (or TOTP endpoint) needs a valid totp_code;
+  // invalid_mfa_code additionally means the supplied code was rejected
+  mfa_required?: true;
+  mfa_types?: string[];
+  invalid_mfa_code?: true;
+  // Validation errors are a map of field -> messages; flag-style errors
+  // (token_expired, mfa_required, ...) use a list of such maps
+  errors?: Record<string, string[]> | Array<Record<string, string[]>>;
 };
 
 type Response = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './sessions'
+export * from './totp'
 export * from './users'
 export * from './errors'

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -8,6 +8,8 @@ import { handleResponseError } from './errors';
 type BaseSessionResponse = {
   api_token: string,
   authenticated_at: string,
+  // "password", "password+totp", or "password+backup_code"
+  authenticated_by: string,
   expires_at: string,
   id: string,
   ip_address: string,
@@ -26,13 +28,17 @@ type IsValidResponse = boolean
 type IsValidWithRoleResponse = boolean
 type SessionResponse = BaseResp & BaseSessionResponse
 
-function login(c: MalanConfig, username: string, password: string, expirationSeconds = 0, maxExtensionSeconds = 0, extendableUntilSeconds = 0): Promise<LoginResponse> {
+// When the user has TOTP MFA enabled, login without totpCode rejects with a
+// MalanError carrying mfa_required: true -- re-submit with totpCode set to a
+// 6-digit TOTP code or a 12-character single-use backup code.
+function login(c: MalanConfig, username: string, password: string, expirationSeconds = 0, maxExtensionSeconds = 0, extendableUntilSeconds = 0, totpCode?: string): Promise<LoginResponse> {
   return superagent
     .post(fullUrl(c, "/api/sessions"))
     .send({
       session: {
         username,
         password,
+        totp_code: totpCode,
         never_expires: expirationSeconds === 0,
         expires_in_seconds: expirationSeconds === 0 ? undefined : expirationSeconds,
         max_extension_secs:  maxExtensionSeconds === 0 ? undefined : maxExtensionSeconds,

--- a/src/totp.test.ts
+++ b/src/totp.test.ts
@@ -1,0 +1,222 @@
+import * as sessions from './sessions';
+import * as totp from './totp';
+import * as users from './users';
+import { MalanError } from './errors';
+import { base, forSession } from '../test/test_config';
+import {
+  avoidTotpStepBoundary,
+  currentTotpCode,
+  invalidTotpCodeFor,
+  previousTotpCode,
+  randomUsername,
+  rootAccount,
+} from '../test/test_helpers';
+
+const backupCodeRegex = /^[a-zA-Z0-9]{12}$/
+
+// A fresh user per test keeps each test inside its own TOTP verify
+// rate-limit budget (5 attempts per 5 minutes per user on a dev server)
+async function newTotpAccount() {
+  const name = randomUsername()
+  const password = `totppass${name}`
+  const { data: user } = await users.createUser(base, {
+    email: `${name}@libmalan.com`,
+    username: name,
+    password,
+    first_name: `Totp${name}`,
+    last_name: "User",
+  })
+  const session = (await sessions.login(base, name, password)).data
+  return { user, password, config: forSession(session) }
+}
+
+// Enroll and confirm. Confirms with the previous step's code so callers can
+// still use the current step's code afterwards (the server refuses to accept
+// a step at or below the last accepted one).
+async function enableTotp(account) {
+  const enrollment = (await totp.startTotpEnrollment(account.config, account.user.id, account.password)).data
+  await avoidTotpStepBoundary()
+  const confirmed = (await totp.confirmTotpEnrollment(account.config, account.user.id, previousTotpCode(enrollment.secret_base32))).data
+  return { secret_base32: enrollment.secret_base32, backup_codes: confirmed.backup_codes }
+}
+
+describe('#getTotpStatus', () => {
+  it('Returns status "none" for a user without TOTP', async () => {
+    const account = await newTotpAccount()
+    const resp = await totp.getTotpStatus(account.config, account.user.id)
+    expect(resp.status).toEqual(200)
+    expect(resp.data.status).toEqual("none")
+    expect(resp.data.confirmed_at).toBeNull()
+    expect(resp.data.backup_codes_remaining).toEqual(0)
+  });
+
+  it('Accepts "current" as the user id', async () => {
+    const account = await newTotpAccount()
+    const resp = await totp.getTotpStatus(account.config, "current")
+    expect(resp.data.status).toEqual("none")
+  });
+
+  it("Rejects reading another user's status", async () => {
+    const account = await newTotpAccount()
+    const other = await newTotpAccount()
+    await expect(totp.getTotpStatus(account.config, other.user.id))
+      .rejects.toMatchObject({ code: 401 })
+  });
+})
+
+describe('#startTotpEnrollment', () => {
+  it('Returns the provisioning payload and moves status to "pending"', async () => {
+    const account = await newTotpAccount()
+    const resp = await totp.startTotpEnrollment(account.config, account.user.id, account.password)
+    expect(resp.status).toEqual(201)
+    expect(resp.data.secret_base32).toMatch(/^[A-Z2-7]+$/)
+    expect(resp.data.otpauth_uri).toMatch(/^otpauth:\/\/totp\//)
+    expect(resp.data.qr_code_svg).toContain("<svg")
+    const status = await totp.getTotpStatus(account.config, account.user.id)
+    expect(status.data.status).toEqual("pending")
+  });
+
+  it('Rejects a wrong password', async () => {
+    const account = await newTotpAccount()
+    const err = await totp.startTotpEnrollment(account.config, account.user.id, "not-the-password").catch(e => e)
+    expect(err).toBeInstanceOf(MalanError)
+    expect(err.code).toEqual(403)
+  });
+})
+
+describe('#confirmTotpEnrollment', () => {
+  it('Returns backup codes and enables TOTP', async () => {
+    const account = await newTotpAccount()
+    const enrollment = (await totp.startTotpEnrollment(account.config, account.user.id, account.password)).data
+    const resp = await totp.confirmTotpEnrollment(account.config, account.user.id, currentTotpCode(enrollment.secret_base32))
+    expect(resp.status).toEqual(200)
+    expect(resp.data.backup_codes).toHaveLength(10)
+    for (const code of resp.data.backup_codes) {
+      expect(code).toMatch(backupCodeRegex)
+    }
+    const status = await totp.getTotpStatus(account.config, account.user.id)
+    expect(status.data.status).toEqual("enabled")
+    expect(status.data.confirmed_at).toBeTruthy()
+    expect(status.data.backup_codes_remaining).toEqual(10)
+  });
+
+  it('Rejects an invalid code', async () => {
+    const account = await newTotpAccount()
+    const enrollment = (await totp.startTotpEnrollment(account.config, account.user.id, account.password)).data
+    await expect(totp.confirmTotpEnrollment(account.config, account.user.id, invalidTotpCodeFor(enrollment.secret_base32)))
+      .rejects.toMatchObject({ code: 403, invalid_mfa_code: true })
+  });
+
+  it('Returns 404 when there is no pending enrollment', async () => {
+    const account = await newTotpAccount()
+    await expect(totp.confirmTotpEnrollment(account.config, account.user.id, "123456"))
+      .rejects.toMatchObject({ code: 404 })
+  });
+})
+
+describe('login with TOTP enabled', () => {
+  it('Requires a code and accepts a valid TOTP code', async () => {
+    const account = await newTotpAccount()
+    const { secret_base32 } = await enableTotp(account)
+
+    const err = await sessions.login(base, account.user.username, account.password).catch(e => e)
+    expect(err).toBeInstanceOf(MalanError)
+    expect(err.code).toEqual(403)
+    expect(err.mfa_required).toEqual(true)
+    expect(err.mfa_types).toEqual(["totp"])
+    expect(err.invalid_mfa_code).toBeUndefined()
+
+    await expect(sessions.login(base, account.user.username, account.password, 0, 0, 0, invalidTotpCodeFor(secret_base32)))
+      .rejects.toMatchObject({ code: 403, mfa_required: true, invalid_mfa_code: true })
+
+    // enableTotp confirmed with the previous step's code, so the current
+    // step's code is still fresh
+    const session = await sessions.login(base, account.user.username, account.password, 0, 0, 0, currentTotpCode(secret_base32))
+    expect(session.api_token).toMatch(/[a-zA-Z0-9]{60}/)
+    expect(session.authenticated_by).toEqual("password+totp")
+  });
+
+  it('Accepts a backup code exactly once', async () => {
+    const account = await newTotpAccount()
+    const { backup_codes } = await enableTotp(account)
+
+    const session = await sessions.login(base, account.user.username, account.password, 0, 0, 0, backup_codes[0])
+    expect(session.api_token).toMatch(/[a-zA-Z0-9]{60}/)
+    expect(session.authenticated_by).toEqual("password+backup_code")
+
+    await expect(sessions.login(base, account.user.username, account.password, 0, 0, 0, backup_codes[0]))
+      .rejects.toMatchObject({ code: 403, invalid_mfa_code: true })
+
+    const status = await totp.getTotpStatus(account.config, account.user.id)
+    expect(status.data.backup_codes_remaining).toEqual(9)
+  });
+})
+
+describe('#regenerateTotpBackupCodes', () => {
+  it('Replaces the backup codes', async () => {
+    const account = await newTotpAccount()
+    const { backup_codes } = await enableTotp(account)
+    const resp = await totp.regenerateTotpBackupCodes(account.config, account.user.id, account.password, backup_codes[0])
+    expect(resp.status).toEqual(200)
+    expect(resp.data.backup_codes).toHaveLength(10)
+    for (const code of resp.data.backup_codes) {
+      expect(code).toMatch(backupCodeRegex)
+      expect(backup_codes.indexOf(code)).toEqual(-1)
+    }
+    const status = await totp.getTotpStatus(account.config, account.user.id)
+    expect(status.data.backup_codes_remaining).toEqual(10)
+  });
+
+  it('Rejects a wrong password', async () => {
+    const account = await newTotpAccount()
+    const { backup_codes } = await enableTotp(account)
+    await expect(totp.regenerateTotpBackupCodes(account.config, account.user.id, "not-the-password", backup_codes[0]))
+      .rejects.toMatchObject({ code: 403 })
+  });
+})
+
+describe('#disableTotp', () => {
+  it('Disables TOTP and allows password-only login again', async () => {
+    const account = await newTotpAccount()
+    const { backup_codes } = await enableTotp(account)
+    const resp = await totp.disableTotp(account.config, account.user.id, account.password, backup_codes[0])
+    expect(resp.status).toEqual(200)
+    expect(resp.data.status).toEqual("none")
+    const session = await sessions.login(base, account.user.username, account.password)
+    expect(session.api_token).toMatch(/[a-zA-Z0-9]{60}/)
+    expect(session.authenticated_by).toEqual("password")
+  });
+
+  it('Returns 404 when TOTP is not enabled', async () => {
+    const account = await newTotpAccount()
+    await expect(totp.disableTotp(account.config, account.user.id, account.password, "123456"))
+      .rejects.toMatchObject({ code: 404 })
+  });
+})
+
+describe('#adminDeleteTotp', () => {
+  it('Force-disables TOTP without password or code', async () => {
+    const account = await newTotpAccount()
+    await enableTotp(account)
+    const root = await rootAccount()
+    const resp = await totp.adminDeleteTotp(forSession(root.session), account.user.id)
+    expect(resp.status).toEqual(200)
+    expect(resp.data.status).toEqual("none")
+    const session = await sessions.login(base, account.user.username, account.password)
+    expect(session.authenticated_by).toEqual("password")
+  });
+
+  it('Returns 404 when the user has no TOTP', async () => {
+    const account = await newTotpAccount()
+    const root = await rootAccount()
+    await expect(totp.adminDeleteTotp(forSession(root.session), account.user.id))
+      .rejects.toMatchObject({ code: 404 })
+  });
+
+  it('Rejects non-admin callers', async () => {
+    const account = await newTotpAccount()
+    const other = await newTotpAccount()
+    await expect(totp.adminDeleteTotp(account.config, other.user.id))
+      .rejects.toMatchObject({ code: 401 })
+  });
+})

--- a/src/totp.ts
+++ b/src/totp.ts
@@ -1,0 +1,103 @@
+const superagent = require('superagent');
+
+import { fullUrl, BaseResp } from './utils';
+
+import MalanConfig from './config';
+import { handleResponseError } from './errors';
+
+type TotpStatus = {
+  status: "none" | "pending" | "enabled",
+  confirmed_at: string | null,
+  backup_codes_remaining: number,
+}
+
+type TotpEnrollment = {
+  secret_base32: string,
+  otpauth_uri: string,
+  qr_code_svg: string,
+}
+
+type TotpBackupCodes = {
+  backup_codes: Array<string>,
+}
+
+type TotpStatusResponse = Omit<BaseResp, 'data'> & { data: TotpStatus }
+type TotpEnrollmentResponse = Omit<BaseResp, 'data'> & { data: TotpEnrollment }
+type TotpBackupCodesResponse = Omit<BaseResp, 'data'> & { data: TotpBackupCodes }
+
+// user_id accepts a UUID, a username, or "current" on all non-admin functions
+
+function getTotpStatus(c: MalanConfig, user_id: string): Promise<TotpStatusResponse> {
+  return superagent
+    .get(fullUrl(c, `/api/users/${user_id}/totp`))
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+// The secret, otpauth URI, and QR code are disclosed only by this call --
+// show them to the user now, they cannot be retrieved again
+function startTotpEnrollment(c: MalanConfig, user_id: string, password: string): Promise<TotpEnrollmentResponse> {
+  return superagent
+    .post(fullUrl(c, `/api/users/${user_id}/totp`))
+    .send({ password })
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+// Returns single-use backup codes (shown only once). Enabling TOTP revokes
+// every other active session for the user; the calling session stays valid.
+function confirmTotpEnrollment(c: MalanConfig, user_id: string, code: string): Promise<TotpBackupCodesResponse> {
+  return superagent
+    .put(fullUrl(c, `/api/users/${user_id}/totp/confirm`))
+    .send({ code })
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+// code accepts a 6-digit TOTP code or a 12-character backup code
+function disableTotp(c: MalanConfig, user_id: string, password: string, code: string): Promise<TotpStatusResponse> {
+  return superagent
+    .post(fullUrl(c, `/api/users/${user_id}/totp/disable`))
+    .send({ password, code })
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+// Invalidates all previous backup codes and returns a fresh set
+function regenerateTotpBackupCodes(c: MalanConfig, user_id: string, password: string, code: string): Promise<TotpBackupCodesResponse> {
+  return superagent
+    .post(fullUrl(c, `/api/users/${user_id}/totp/backup_codes`))
+    .send({ password, code })
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+// Admin recovery path for users locked out of MFA. Requires no password or
+// code and revokes all of the target user's active sessions.
+function adminDeleteTotp(c: MalanConfig, user_id: string): Promise<TotpStatusResponse> {
+  return superagent
+    .delete(fullUrl(c, `/api/admin/users/${user_id}/totp`))
+    .set('Authorization', `Bearer ${c.api_token}`)
+    .then(resp => ({ ...resp, data: { ...resp.body.data }, ok: true }))
+    .catch(handleResponseError)
+}
+
+export {
+  TotpStatus,
+  TotpEnrollment,
+  TotpBackupCodes,
+  TotpStatusResponse,
+  TotpEnrollmentResponse,
+  TotpBackupCodesResponse,
+  getTotpStatus,
+  startTotpEnrollment,
+  confirmTotpEnrollment,
+  disableTotp,
+  regenerateTotpBackupCodes,
+  adminDeleteTotp,
+}

--- a/test/test_config.ts
+++ b/test/test_config.ts
@@ -1,7 +1,7 @@
 import MalanConfig from '../src/config';
 
 export const base = {
-  host: "0.0.0.0:4000",
+  host: process.env.MALAN_HOST || "0.0.0.0:4000",
   api_token: "",
 }
 

--- a/test/test_helpers.ts
+++ b/test/test_helpers.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 import * as users from '../src/users';
 import * as sessions from '../src/sessions';
 
@@ -108,6 +110,73 @@ export async function newRegularAccount(): Promise<users.BaseUserResp & { sessio
 }
 
 export const uuidRegex = /[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{10}/
+
+// TOTP (RFC 6238) code generation, used to drive the real MFA endpoints in
+// tests. Malan uses NimbleTOTP defaults: HMAC-SHA1, 6 digits, 30-second
+// steps, accepting the current or previous step. Replay protection means an
+// accepted step can never be used again for that user.
+
+export const TOTP_PERIOD_SECS = 30
+
+function base32Decode(encoded: string): Buffer {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+  let bits = 0
+  let value = 0
+  const bytes = []
+  for (const char of encoded.toUpperCase().replace(/=+$/, "")) {
+    const index = alphabet.indexOf(char)
+    if (index === -1) {
+      throw new Error(`Invalid base32 character: ${char}`)
+    }
+    value = (value << 5) | index
+    bits += 5
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff)
+      bits -= 8
+    }
+  }
+  return Buffer.from(bytes)
+}
+
+export function totpCodeAt(secretBase32: string, timeSecs: number): string {
+  const step = Math.floor(timeSecs / TOTP_PERIOD_SECS)
+  const counter = Buffer.alloc(8)
+  counter.writeUInt32BE(Math.floor(step / 0x100000000), 0)
+  counter.writeUInt32BE(step % 0x100000000, 4)
+  const digest = crypto.createHmac("sha1", base32Decode(secretBase32)).update(counter).digest()
+  const offset = digest[digest.length - 1] & 0x0f
+  const binary =
+    ((digest[offset] & 0x7f) << 24) |
+    (digest[offset + 1] << 16) |
+    (digest[offset + 2] << 8) |
+    digest[offset + 3]
+  const code = String(binary % 1000000)
+  return "000000".slice(code.length) + code
+}
+
+export const nowSecs = () => Math.floor(Date.now() / 1000)
+
+export const currentTotpCode = (secretBase32: string) => totpCodeAt(secretBase32, nowSecs())
+
+export const previousTotpCode = (secretBase32: string) =>
+  totpCodeAt(secretBase32, nowSecs() - TOTP_PERIOD_SECS)
+
+// A code that is valid for neither the current nor the previous step
+export function invalidTotpCodeFor(secretBase32: string): string {
+  const valid = [currentTotpCode(secretBase32), previousTotpCode(secretBase32)]
+  return ["000000", "111111", "222222"].find((code) => valid.indexOf(code) === -1)
+}
+
+// Tests that verify two codes back to back confirm enrollment with the
+// previous step's code, then use the current step's for the next call.
+// That pairing breaks if the clock crosses a step boundary between the two
+// requests, so wait out the boundary when it is close.
+export async function avoidTotpStepBoundary(marginSecs = 3): Promise<void> {
+  const intoStep = nowSecs() % TOTP_PERIOD_SECS
+  if (intoStep >= TOTP_PERIOD_SECS - marginSecs) {
+    await new Promise((resolve) => setTimeout(resolve, (TOTP_PERIOD_SECS - intoStep + 1) * 1000))
+  }
+}
 
 export function testUser() {
 


### PR DESCRIPTION
Wrap the new Malan TOTP endpoints (status, enrollment, confirm, disable, backup code regeneration, admin force-disable) in a new totp module. login() accepts an optional totpCode and session responses include authenticated_by; MalanError carries the MFA error fields. Integration tests generate real RFC 6238 codes, and the test host is overridable via MALAN_HOST.